### PR TITLE
Update Handler jsdoc types

### DIFF
--- a/twig.js
+++ b/twig.js
@@ -40,10 +40,10 @@ const Any = new AnyHandler();
 * Reference to handler functions for Twig objects.<br> 
 * Element can be specified as string, Regular Expression, custom function, `Twig.Root` or `Twig.Any`<br> 
 * You can specify a `function` or a `event` name
-* @typedef TwigHandler 
+* @typedef TwigHandler
 * @property {HandlerCondition} tag - Element specification
-* @property {?HandlerFunction} function - Definition of handler function, either anonymous or explicit function
-* @property {?string} event - Type of the event to be emitted
+* @property {HandlerFunction} [function] - Definition of handler function, either anonymous or explicit function
+* @property {string} [event] - Type of the event to be emitted
 */
 
 /**
@@ -59,8 +59,8 @@ const Any = new AnyHandler();
 
 /**
 * Handler function for Twig objects, i.e. the way you like to use the XML element.
-* @typedef HandlerFunction 
-* @property {Twig} elt - The current Twig element on which the function was called.
+* @typedef {function} HandlerFunction 
+* @param {Twig} elt - The current Twig element on which the function was called.
 */
 
 /**


### PR DESCRIPTION
Hello again! Sorry for the multiple PRs. When implementing the new update into my project I found some minor things that I had missed that cropped up due to the types being propogated now.

This just touches the `TwigHandler` and associated `HandlerFunction` types. No code changes for this one, all jsdoc.