### PR TITLE
Update private variable typings

### DIFF
--- a/twig.js
+++ b/twig.js
@@ -26,7 +26,7 @@ const Any = new AnyHandler();
 /**
 * Optional settings for the Twig parser
 * @typedef ParserOptions 
-* @property {string} [method] - The underlying parser. Either `'sax'` or `'expat'`.
+* @property {'sax' | 'expat'} [method] - The underlying parser. Either `'sax'` or `'expat'`.
 * @property {string} [encoding] - Encoding of the XML File. Applies only to `expat` parser.
 * @property {boolean} [xmlns] - If `true`, then namespaces are accessible by `namespace` property.
 * @property {boolean} [trim] - If `true`, then turn any whitespace into a single space. Text and comments are trimmed.
@@ -103,8 +103,8 @@ function createParser(handler, options) {
    let closeEvent;
 
    if (options.partial) {
-      let hndl = Array.isArray(handler) ? handler : [handler];
-      let any = hndl.find(x => x.tag instanceof AnyHandler);
+      const handle1 = Array.isArray(handler) ? handler : [handler];
+      let any = handle1.find(x => x.tag instanceof AnyHandler);
       if (any !== undefined)
          console.warn(`Using option '{ partial: true }' and handler '{ tag: Any, function: ${any.function.toString()} }' does not make much sense`);
    }
@@ -391,38 +391,38 @@ class Twig {
    */
 
    /**
-   * @property {?object} #attributes - XML attribute `{ <attribute 1>: <value 1>, <attribute 2>: <value 2>, ... }`
-   * @private
+    * XML attribute `{ <attribute 1>: <value 1>, <attribute 2>: <value 2>, ... }`
+   * @type {?object}
    */
    #attributes = {};
 
    /**
-   * @property {?string|number} #text - Content of XML Element
-   * @private
+    * Content of XML Element
+   * @type {?string|number}
    */
    #text = null;
 
    /**
-   * @property {string} #name - The XML tag name
-   * @private
+    * The XML tag name
+   * @type {string} 
    */
    #name;
 
    /**
-   * @property {?Twig[]} #children - Child XML Elements
-   * @private
+    * Child XML Elements
+   * @type {Twig[]}
    */
    #children = [];
 
    /**
-   * @property {?Twig} #parent - The parent object. Undefined on root element
-   * @private
+    * The parent object. Undefined on root element
+   * @type {Twig | undefined} 
    */
    #parent;
 
    /**
-   * @property {boolean} #pinned - Determines whether twig is needed in partial load
-   * @private
+    * Determines whether twig is needed in partial load
+   * @type {boolean}
    */
    #pinned = false;
 
@@ -482,14 +482,14 @@ class Twig {
       if (elt === undefined) {
          this.purge();
       } else {
-         let purgeThis = this.descendantOrSelf();
-         purgeThis = purgeThis[purgeThis.length - 1];
-         let stopAt = elt.descendantOrSelf();
-         stopAt = stopAt[stopAt.length - 1];
-         while (purgeThis !== null && !Object.is(purgeThis, stopAt)) {
-            let prev = purgeThis.previous();
-            purgeThis.purge();
-            purgeThis = prev;
+         const purgeThis = this.descendantOrSelf();
+         let toPurge = purgeThis[purgeThis.length - 1];
+         const descendantOrSelf = elt.descendantOrSelf();
+         const stopAt = descendantOrSelf[descendantOrSelf.length - 1];
+         while (toPurge !== null && !Object.is(toPurge, stopAt)) {
+            const prev = toPurge.previous();
+            toPurge.purge();
+            toPurge = prev;
          }
       }
    };


### PR DESCRIPTION
Hey, sorry for the delay, as I mentioned in my previous PR there were a few typings that were still throwing some errors. I think I've gotten to the bottom of most of them here.

## Changes

- Removed `@private` from variable definitions. The `#` and the `private` modifier are conflicting but do similar things.
- Renamed a duplicated variable name just for the sake of clarity
- Amended some variable declaration for the `purgeUp`To function

## Outstanding type errors

![image](https://github.com/Wernfried/xml-twig/assets/3467306/ac231a68-3e74-4e3c-a941-a7300e6d7e21)

![image](https://github.com/Wernfried/xml-twig/assets/3467306/e0527fb4-653a-4442-b7b8-903795710f27)

There are a few of this one, but I believe that this is caused by the inner function looking at the parameter definition of the containing function, and not taking into account the `options = Object.assign({ method: SAX, encoding: 'UTF-8', xmlns: false, trim: true, resumeAfterError: false, partial: false }, options);` line

![image](https://github.com/Wernfried/xml-twig/assets/3467306/e2100c2c-c3ea-4354-adc8-ec535c65a882)

This function seems to be referencing properties that are not present on the `attr` parameter.

![image](https://github.com/Wernfried/xml-twig/assets/3467306/a15ebbd9-c68b-4fed-b952-3eae0ba8ec9b)

`encoding` isn't present on the `parser`

![image](https://github.com/Wernfried/xml-twig/assets/3467306/3138c432-9b11-425d-8fa7-f87f835b88ae)

This one seems to be being caused by typescript not being smart enough to realise the undefined check is being done in `this.isRoot`

Additionally the typings for `XmlWriter` do not seeem to be playing nicely.

## Conclusion

I believe that most of the above typing errors are relatively harmless and don't need to be urgently addressed.